### PR TITLE
Add image building and infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ tags
 .env*
 terraform.*
 .terraform.*
+*.tfstate

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 cscope.*
 tags
 .env*
+terraform.*
+.terraform.*

--- a/Makefile
+++ b/Makefile
@@ -94,8 +94,9 @@ integration-tests:
 
 integration-teardown: decrypt_integration_dotenv
 integration-teardown:
+	export $$(grep -Ev '^#' "$(PWD)/.env.integration" | xargs -0); \
 	export ENVIRONMENT=integration; \
-	$(DOCKER_COMPOSE_TERRAFORM) run --rm terraform-init &&
+	$(DOCKER_COMPOSE_TERRAFORM) run --rm terraform-init && \
 	$(DOCKER_COMPOSE_TERRAFORM) run --rm terraform-destroy
 
 # NOTE: production-{setup,deploy}

--- a/README.md
+++ b/README.md
@@ -31,11 +31,44 @@ This project spins up an AWS Elastic Kubernetes Services (EKS) cluster with a
 single `t3g.medium` spot worker. As such, you'll need an AWS account in order to run
 the integration tests.
 
+**At this time of writing, this will cost ~$0.15/hr to operate.**
+
 [Go
 here](https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-creating.html)
 to learn how to create an AWS account if you do not already have one.
 
-**At this time of writing, this will cost ~$0.15/hr to operate.**
+### Configuring IAM
+
+Once you've created your AWS account, you will need to create a user that can
+assume the `AWSAdministrator` role within AWS Identity Access Management (IAM)
+via the AWS Security Token Service (STS). STS prevents you from having to
+create an overly-privileged superuser within IAM by issuing temporary tokens
+that expire within a short duration (less than 12 hours).
+
+Download and install the AWS CLI if you have not already done so.
+
+Once done, [visit this
+page](https://repost.aws/knowledge-center/iam-assume-role-cli) to learn how to
+do this, then in your `env.integration` and `env.production` dotenvs, populate
+the following:
+
+```sh
+AWS_ACCESS_KEY_ID=$IAM_USER_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY=$IAM_USER_SECRET_ACCESS_KEY
+AWS_ROLE_ARN=$NAME_OF_ROLE_THAT_YOU_CREATED
+# see the note below to learn how to generate this
+AWS_EXTERNAL_ID=$EXTERNAL_ID_FOR_THE_ROLE_THAT_YOU_CREATED
+```
+
+> ✅ **NOTE**: External IDs are kind-of like passwords for accounts trying to
+> assume roles. They prevent unknown users from trying to assume roles. Add the
+> JSON to your trust policy JSON document to add an "external ID" to the IAM
+> role's trust policy JSON document:
+>
+> ```json
+> "Condition": {"StringEquals": {"sts:ExternalId": "$RANDOM_PASSWORD"}}
+> ```
+
 
 ### Environment dotfiles (dotenvs)
 

--- a/docker-compose.aws.yml
+++ b/docker-compose.aws.yml
@@ -1,0 +1,46 @@
+version: '2.2'
+services:
+  aws:
+    image: amazon/aws-cli:2.2.9
+    env_file: .env
+    environment:
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_ROLE_ARN
+      - AWS_SESSION_NAME
+      - AWS_SESSION_TOKEN
+  obtain-aws-session-credentials:
+    extends: aws
+    environment:
+      AWS_SESSION_TOKEN: ""
+    volumes:
+      - ${TMPDIR:-/tmp}/.aws-sts-token-data:/tmp
+    entrypoint: sh
+    command:
+      - -c
+      - |
+        if test -f /tmp/aws_token && test -f /tmp/aws_token_exp
+        then
+          now=$(date +%s)
+          exp=$(cat /tmp/aws_token_exp)
+          if test -z "$$exp" || test "$$now" -lt "$$exp"
+          then
+            >&2 echo "INFO: Existing unexpired token; returning"
+            cat /tmp/aws_token
+            exit 0
+          fi
+        fi
+        >&2 echo "INFO: Renewing AWS session token."
+        aws_token=$(aws sts assume-role \
+          --role-arn "$AWS_ROLE_ARN" \
+          --external-id "$AWS_STS_EXTERNAL_ID" \
+          --role-session-name "$AWS_SESSION_NAME" \
+           --query 'join(``, [
+                    `\nexport `, `AWS_ACCESS_KEY_ID=`, Credentials.AccessKeyId,
+                    `\nexport `, `AWS_SECRET_ACCESS_KEY=`, Credentials.SecretAccessKey,
+                    `\nexport `, `AWS_SESSION_TOKEN=`, Credentials.SessionToken
+                    ])' \
+          --output text) || exit 1
+        date -d '+1 hour' +%s > /tmp/aws_token_exp
+        >&2 echo "INFO: Token renewed; expires in an hour."
+        echo "$$aws_token" | tee /tmp/aws_token

--- a/docker-compose.aws.yml
+++ b/docker-compose.aws.yml
@@ -9,6 +9,42 @@ services:
       - AWS_ROLE_ARN
       - AWS_SESSION_NAME
       - AWS_SESSION_TOKEN
+      - AWS_REGION
+  update-eks-kubeconfig:
+    extends: aws
+    volumes:
+      - ${TMPDIR:-/tmp}:/tmp
+    environment:
+      - CLUSTER_NAME
+    # This command writes a kubeconfig that does not require retrieving
+    # a token via the aws-cli at runtime.
+    entrypoint: sh
+    command:
+      - -c
+      - |
+        server=$(aws eks describe-cluster --name "$CLUSTER_NAME" --query 'cluster.endpoint' --output text)
+        token=$(aws eks get-token --cluster-name "$CLUSTER_NAME" --query 'status.token' --output text)
+        cert_data=$(aws eks describe-cluster --name "$CLUSTER_NAME" --query 'cluster.certificateAuthority.data' --output text)
+        cat >/tmp/kubeconfig <<-EOF
+        apiVersion: v1
+        kind: Config
+        preferences: {}
+        current-context: context
+        clusters:
+          - name: cluster
+            cluster:
+              certificate-authority-data: $$cert_data
+              server: $$server
+        users:
+          - name: user
+            user:
+              token: $$token
+        contexts:
+          - name: context
+            context:
+              cluster: cluster
+              user: user
+        EOF
   obtain-aws-session-credentials:
     extends: aws
     environment:

--- a/docker-compose.aws.yml
+++ b/docker-compose.aws.yml
@@ -1,7 +1,7 @@
 version: '2.2'
 services:
   aws:
-    image: amazon/aws-cli:2.2.9
+    image: amazon/aws-cli:2.13.9
     env_file: .env
     environment:
       - AWS_ACCESS_KEY_ID
@@ -59,7 +59,7 @@ services:
         then
           now=$(date +%s)
           exp=$(cat /tmp/aws_token_exp)
-          if test -z "$$exp" || test "$$now" -lt "$$exp"
+          if test -n "$$exp" && test "$$now" -lt "$$exp"
           then
             >&2 echo "INFO: Existing unexpired token; returning"
             cat /tmp/aws_token
@@ -67,7 +67,7 @@ services:
           fi
         fi
         >&2 echo "INFO: Renewing AWS session token."
-        token_duration_minutes=15; \
+        token_duration_minutes=60; \
         aws_token=$(aws sts assume-role \
           --role-arn "$AWS_ROLE_ARN" \
           --external-id "$AWS_STS_EXTERNAL_ID" \
@@ -79,6 +79,6 @@ services:
                     `\nexport `, `AWS_SESSION_TOKEN=`, Credentials.SessionToken
                     ])' \
           --output text) || exit 1
-        date -d '+1 hour' +%s > /tmp/aws_token_exp
+        date -d "+$$token_duration_minutes min" +%s > /tmp/aws_token_exp
         >&2 echo "INFO: Token renewed; expires in $$token_duration_minutes minutes."
         echo "$$aws_token" | tee /tmp/aws_token

--- a/docker-compose.aws.yml
+++ b/docker-compose.aws.yml
@@ -22,6 +22,17 @@ services:
     command:
       - -c
       - |
+        if test -f /tmp/.aws-kubeconfig-exp
+        then
+          now=$(date +%s)
+          exp=$(cat /tmp/.aws-kubeconfig-exp)
+          if test "$$now" -lt "$$exp"
+          then
+            >&2 echo "INFO: EKS cluster token still valid; returning previous Kubeconfig"
+            exit 0
+          fi
+        fi
+        test -f /tmp/kubeconfig && rm  /tmp/kubeconfig
         server=$(aws eks describe-cluster --name "$CLUSTER_NAME" --query 'cluster.endpoint' --output text)
         token=$(aws eks get-token --cluster-name "$CLUSTER_NAME" --query 'status.token' --output text)
         cert_data=$(aws eks describe-cluster --name "$CLUSTER_NAME" --query 'cluster.certificateAuthority.data' --output text)
@@ -45,6 +56,7 @@ services:
               cluster: cluster
               user: user
         EOF
+        date -d "+10 minutes" +%s > /tmp/.aws-kubeconfig-exp
   obtain-aws-session-credentials:
     extends: aws
     environment:

--- a/docker-compose.aws.yml
+++ b/docker-compose.aws.yml
@@ -31,10 +31,12 @@ services:
           fi
         fi
         >&2 echo "INFO: Renewing AWS session token."
+        token_duration_minutes=15; \
         aws_token=$(aws sts assume-role \
           --role-arn "$AWS_ROLE_ARN" \
           --external-id "$AWS_STS_EXTERNAL_ID" \
           --role-session-name "$AWS_SESSION_NAME" \
+          --duration-seconds $$((60*$$token_duration_minutes)) \
            --query 'join(``, [
                     `\nexport `, `AWS_ACCESS_KEY_ID=`, Credentials.AccessKeyId,
                     `\nexport `, `AWS_SECRET_ACCESS_KEY=`, Credentials.SecretAccessKey,
@@ -42,5 +44,5 @@ services:
                     ])' \
           --output text) || exit 1
         date -d '+1 hour' +%s > /tmp/aws_token_exp
-        >&2 echo "INFO: Token renewed; expires in an hour."
+        >&2 echo "INFO: Token renewed; expires in $$token_duration_minutes minutes."
         echo "$$aws_token" | tee /tmp/aws_token

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,5 +1,9 @@
 version: '2.2'
 services:
+  helm:
+    build:
+      dockerfile: helm.Dockerfile
+      context: .
   gpg:
     build:
       dockerfile: gpg.Dockerfile

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -4,6 +4,9 @@ services:
     build:
       dockerfile: helm.Dockerfile
       context: .
+    volumes:
+      - ${TMPDIR:-/tmp}/kubeconfig:/tmp/kubeconfig
+      - $PWD/chart:/chart
   gpg:
     build:
       dockerfile: gpg.Dockerfile

--- a/docker-compose.terraform.yaml
+++ b/docker-compose.terraform.yaml
@@ -1,12 +1,13 @@
 version: '2.6'
 volumes:
-  tf-data: {}
+  tfdata: {}
 services:
   terraform:
     image: hashicorp/terraform:1.6.5
     environment:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
       - AWS_REGION
       - TF_DATA_DIR=/terraform-data
       - TF_WORKSPACE=$ENVIRONMENT
@@ -16,25 +17,32 @@ services:
     working_dir: /infra
   terraform-init:
     extends: terraform
-    entrypoint: bash
+    entrypoint: sh
     command:
       - -c
       - |
         cat >/backend.tfvars <<-EOF
-        bucket = $TERRAFORM_STATE_S3_BUCKET
-        key = $TERRAFORM_STATE_S3_KEY
+        bucket = "$TERRAFORM_STATE_S3_BUCKET"
+        key = "$TERRAFORM_STATE_S3_KEY"
+        region = "$AWS_REGION"
         EOF
         terraform init -backend-config=/backend.tfvars
   terraform-plan:
     extends: terraform
     command:
       - plan
-      - input=false
+      - -input=false
   terraform-apply:
     extends: terraform
     command:
       - apply
       - -auto-approve
+  terraform-output:
+    extends: terraform
+    entrypoint:
+      - terraform
+      - output
+      - -raw
   terraform-destroy:
     extends: terraform
     command:

--- a/env.example
+++ b/env.example
@@ -3,3 +3,6 @@ TERRAFORM_STATE_S3_KEY=change-me
 AWS_ACCESS_KEY_ID=change-me
 AWS_SECRET_ACCESS_KEY=change-me
 AWS_REGION=us-east-2
+IMAGE_REPO=change-me
+IMAGE_REPO_USERNAME=change-me
+IMAGE_REPO_PASSWORD=change-me

--- a/helm.Dockerfile
+++ b/helm.Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox:1.36.1 AS base
+FROM alpine:3.18 AS base
 ARG HELM_VERSION=3.13.2
 ARG ARCH=arm64
 
@@ -6,7 +6,9 @@ WORKDIR /tmp
 RUN wget -O ./helm.tar.gz https://get.helm.sh/helm-v${HELM_VERSION}-linux-${ARCH}.tar.gz
 RUN tar -xvzf ./helm.tar.gz
 RUN mv linux-${ARCH}/helm /tmp
+RUN apk add --no-cache ca-certificates
 
 FROM scratch
 COPY --from=base /tmp/helm /helm
+COPY --from=base /etc/ssl/certs /etc/ssl/certs
 ENTRYPOINT [ "/helm" ]

--- a/helm.Dockerfile
+++ b/helm.Dockerfile
@@ -1,0 +1,12 @@
+FROM busybox:1.36.1 AS base
+ARG HELM_VERSION=3.13.2
+ARG ARCH=arm64
+
+WORKDIR /tmp
+RUN wget -O ./helm.tar.gz https://get.helm.sh/helm-v${HELM_VERSION}-linux-${ARCH}.tar.gz
+RUN tar -xvzf ./helm.tar.gz
+RUN mv linux-${ARCH}/helm /tmp
+
+FROM scratch
+COPY --from=base /tmp/helm /helm
+ENTRYPOINT [ "/helm" ]

--- a/infra/config.tf
+++ b/infra/config.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {}
+  required_providers {
+    aws = {
+      version = "5.29.0"
+      source  = "hashicorp/aws"
+    }
+  }
+}

--- a/infra/eks.tf
+++ b/infra/eks.tf
@@ -31,25 +31,18 @@ module "eks" {
   subnet_ids               = module.vpc.private_subnets
   control_plane_subnet_ids = module.vpc.public_subnets
   eks_managed_node_group_defaults = {
-    instance_types = ["t4g.large"]
+    instance_types = ["t4g.medium"]
     capacity_type  = "SPOT"
     desired_size   = 1
     min_size       = 1
+    max_size       = 1
   }
-  aws_auth_users = [
-    {
-      userarn  = data.aws_caller_identity.self.arn
-      username = "self"
-      groups   = ["system:masters"]
+  eks_managed_node_groups = {
+    default = {
+      ami_type = "BOTTLEROCKET_ARM_64"
     }
+  }
+  aws_auth_accounts = [
+    data.aws_caller_identity.self.account_id
   ]
-}
-
-module "eks-kubeconfig" {
-  depends_on = [
-    module.eks
-  ]
-  source       = "hyperbadger/eks-kubeconfig/aws"
-  version      = "2.0.0"
-  cluster_name = module.eks.cluster_name
 }

--- a/infra/eks.tf
+++ b/infra/eks.tf
@@ -1,0 +1,55 @@
+data "aws_caller_identity" "self" {}
+
+data "aws_region" "current" {}
+
+resource "random_string" "role_suffix" {
+  length  = 8
+  special = false
+  upper   = false
+  numeric = false
+}
+
+module "eks" {
+  source                         = "terraform-aws-modules/eks/aws"
+  version                        = "19.20.0"
+  cluster_name                   = "example-app-cluster"
+  cluster_version                = "1.27"
+  cluster_endpoint_public_access = true
+  cluster_addons = {
+    coredns = {
+      most_recent       = true
+      resolve_conflicts = "OVERWRITE"
+    }
+    vpc-cni = {
+      most_recent = true
+    }
+    kube-proxy = {
+      most_recent = true
+    }
+  }
+  vpc_id                   = module.vpc.vpc_id
+  subnet_ids               = module.vpc.private_subnets
+  control_plane_subnet_ids = module.vpc.public_subnets
+  eks_managed_node_group_defaults = {
+    instance_types = ["t3g.medium"]
+    capacity_type  = "SPOT"
+    desired_size   = 1
+    min_size       = 1
+  }
+  aws_auth_users = [
+    {
+      userarn  = data.aws_caller_identity.self.arn
+      username = "self"
+      groups   = ["system:masters"]
+    }
+  ]
+}
+
+module "eks-kubeconfig" {
+  depends_on = [
+    module.eks
+  ]
+  source       = "hyperbadger/eks-kubeconfig/aws"
+  version      = "2.0.0"
+  cluster_name = module.eks.cluster_name
+}

--- a/infra/eks.tf
+++ b/infra/eks.tf
@@ -1,13 +1,5 @@
-data "aws_caller_identity" "self" {}
-
 data "aws_region" "current" {}
-
-resource "random_string" "role_suffix" {
-  length  = 8
-  special = false
-  upper   = false
-  numeric = false
-}
+data "aws_caller_identity" "self" {}
 
 module "eks" {
   source                         = "terraform-aws-modules/eks/aws"

--- a/infra/eks.tf
+++ b/infra/eks.tf
@@ -31,7 +31,7 @@ module "eks" {
   subnet_ids               = module.vpc.private_subnets
   control_plane_subnet_ids = module.vpc.public_subnets
   eks_managed_node_group_defaults = {
-    instance_types = ["t3g.medium"]
+    instance_types = ["t4g.large"]
     capacity_type  = "SPOT"
     desired_size   = 1
     min_size       = 1

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,4 @@
+output "kubeconfig" {
+  value = module.eks-kubeconfig.kubeconfig
+  sensitive = true
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,4 +1,3 @@
-output "kubeconfig" {
-  value = module.eks-kubeconfig.kubeconfig
-  sensitive = true
+output "cluster_name" {
+  value = module.eks.cluster_name
 }

--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -1,0 +1,21 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+module "vpc" { # E: This module is not yet installed. Run "terraform init" to install all modules required by this configuration.
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "5.2.0"
+
+  name = "example-app-vpc"
+  cidr = "172.16.0.0/16"
+
+  private_subnets = ["172.16.0.0/24",
+    "172.16.1.0/24",
+  "172.16.2.0/24"]
+  public_subnets = ["172.16.3.0/24",
+    "172.16.4.0/24",
+  "172.16.5.0/24"]
+  enable_nat_gateway = true
+  azs                = slice(sort(data.aws_availability_zones.available.names), 0, 3)
+}
+


### PR DESCRIPTION
This commit adds code to enable us to build and push images to a
repository and stand up infrastructure.

Decisions:

- We are using GHCR for the image repository to avoid Docker Hub's pull
  rate limits.
- We are using AWS EKS with a single-node ARM worker. This will save
  money while providing better CPU performance. In a real-world
  scenario, we'd probably have to defer to `amd64` workers since most
  workloads haven't moved over yet.
- We are using Terraform for infrastructure provisioning because it
  rocks.

Signed-off-by: Carlos Nunez <13461447+carlosonunez@users.noreply.github.com>

